### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ The app is bootstrapped with Vite + React + TypeScript and uses React Query for 
 - `src/utils` – Calculation helpers for hitpoints and defensive mitigation pipelines
 
 Future iterations will move heavy simulations into a Web Worker and expand the defensive ability engine.
+
+## Deploying to GitHub Pages
+
+The repository includes a GitHub Actions workflow that publishes the Vite build output to GitHub Pages. To see the app live:
+
+1. Push this project to a GitHub repository using the `main` branch.
+2. In your repository settings, enable **GitHub Pages** and choose **GitHub Actions** as the source (Pages will suggest the recommended workflow).
+3. On every push to `main`, the `Deploy to GitHub Pages` workflow installs dependencies, builds the project and deploys the `dist/` output to GitHub Pages.
+4. Your site will be available at `https://<username>.github.io/<repository-name>/` once the workflow completes.
+
+The Vite configuration automatically sets the correct base path during production builds when it detects the GitHub repository name, ensuring that asset URLs resolve correctly on GitHub Pages.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    open: true
-  }
+export default defineConfig(({ mode }) => {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const repoName = repository?.split('/')[1];
+  const base = mode === 'production' && repoName ? `/${repoName}/` : '/';
+
+  return {
+    base,
+    plugins: [react()],
+    server: {
+      port: 5173,
+      open: true
+    }
+  };
 });


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Vite app and publishes it to GitHub Pages
- set the Vite base path automatically during production builds to match the repository name
- document the GitHub Pages deployment steps in the README

## Testing
- Not run (dependency installation blocked in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e429e9a8cc83308fdcd1320f38445d