### PR TITLE
Add GitHub Pages SPA routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,10 @@ The repository includes a GitHub Actions workflow that publishes the Vite build 
 3. On every push to `main`, the `Deploy to GitHub Pages` workflow installs dependencies, builds the project and deploys the `dist/` output to GitHub Pages.
 4. Your site will be available at `https://<username>.github.io/<repository-name>/` once the workflow completes.
 
+### Handling single-page routing on GitHub Pages
+
+GitHub Pages serves the deployed bundle from a static file host and does not automatically route deep links (for example `/boss/arch-glacor`) back to the SPA entry point. The project ships with a specialised `404.html` that lives alongside the build output and captures unknown URLs. It performs a lightweight redirect that preserves the requested path and hands it back to the Vite application shell on load.
+
+No extra configuration is required—when a visitor refreshes a deep link, the redirect shim rewrites the URL and `src/utils/githubPagesRedirect.ts` restores the correct in-app route before React mounts. This keeps bookmarking and sharing of planner configurations working reliably across both local development and the GitHub Pages deployment.
+
 The Vite configuration automatically sets the correct base path during production builds when it detects the GitHub repository name, ensuring that asset URLs resolve correctly on GitHub Pages.

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>RuneScape Defensive Lab</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at 20% 20%, rgba(94, 234, 212, 0.12), transparent 45%),
+          radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.14), transparent 50%),
+          #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        text-align: center;
+        padding: 2rem;
+      }
+
+      h1 {
+        font-size: clamp(1.5rem, 3vw, 2.25rem);
+        margin-bottom: 0.75rem;
+      }
+
+      p {
+        max-width: 32rem;
+        margin: 0 auto 2rem;
+        line-height: 1.6;
+      }
+
+      .spinner {
+        width: 3rem;
+        height: 3rem;
+        border-radius: 999px;
+        border: 0.35rem solid rgba(226, 232, 240, 0.24);
+        border-top-color: rgba(45, 212, 191, 0.9);
+        animation: spin 1s linear infinite;
+      }
+
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting you back to the defensive lab…</h1>
+      <p>
+        We could not find the requested page directly, so we are safely routing you back to the
+        application shell.
+      </p>
+      <div class="spinner" aria-hidden="true"></div>
+    </main>
+    <script>
+      (function () {
+        var l = window.location;
+        var segments = l.pathname.split('/').filter(Boolean);
+        var isGitHubHost = /\.github\.io$/i.test(l.hostname);
+        var segmentCount = isGitHubHost && segments.length > 0 ? 1 : 0;
+
+        var baseSegments = l.pathname.split('/').slice(0, segmentCount + 1).join('/');
+        if (!baseSegments || baseSegments === '/') {
+          baseSegments = '/';
+        } else if (!baseSegments.endsWith('/')) {
+          baseSegments += '/';
+        }
+
+        var targetPath = l.pathname
+          .slice(1)
+          .split('/')
+          .slice(segmentCount)
+          .join('/')
+          .replace(/&/g, '~and~');
+
+        var search = l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '';
+        var redirectUrl =
+          l.protocol +
+          '//' +
+          l.host +
+          baseSegments +
+          '?p=/' +
+          targetPath +
+          search +
+          l.hash;
+
+        l.replace(redirectUrl);
+      })();
+    </script>
+  </body>
+</html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import './styles/tailwind.css';
 import { ApiProvider } from './state/ApiProvider';
 import { UserConfigProvider } from './state/UserConfigContext';
+import { restoreSpaRouteFromGithubPages } from './utils/githubPagesRedirect';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,6 +16,8 @@ const queryClient = new QueryClient({
     }
   }
 });
+
+restoreSpaRouteFromGithubPages();
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 

--- a/src/utils/githubPagesRedirect.ts
+++ b/src/utils/githubPagesRedirect.ts
@@ -1,0 +1,23 @@
+function decodeParam(value: string | null): string {
+  if (!value) return '';
+  return decodeURIComponent(value).replace(/~and~/g, '&');
+}
+
+export function restoreSpaRouteFromGithubPages(): void {
+  if (typeof window === 'undefined') return;
+  const search = window.location.search;
+  if (!search.includes('?p=')) return;
+
+  const params = new URLSearchParams(search);
+  const path = decodeParam(params.get('p'));
+  if (!path) return;
+
+  const query = decodeParam(params.get('q'));
+  const hash = window.location.hash ?? '';
+
+  const base = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const newUrl = `${base}${normalizedPath}${query ? `?${query}` : ''}${hash}` || '/';
+
+  window.history.replaceState(null, '', newUrl);
+}


### PR DESCRIPTION
## Summary
- add a GitHub Pages-friendly 404 redirect page that preserves deep link paths
- restore rewritten URLs before React mounts so the SPA handles refreshed links correctly
- document the new routing shim and behaviour in the deployment guide

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e42ca442f88330bfdcd9d9d0d5eb1a