### PR TITLE
Fix TanStack Query v5 compatibility for GitHub Pages build

### DIFF
--- a/src/api/registry.ts
+++ b/src/api/registry.ts
@@ -1,3 +1,4 @@
+import type { QueryKey } from '@tanstack/react-query';
 import { fetchArmor } from './armor';
 import { fetchPrayers } from './supportingData';
 import { fetchAuras } from './supportingData';
@@ -7,7 +8,7 @@ import { CombatStyle } from '../types/config';
 
 export const apiRegistry: Array<{
   key: string;
-  queryKey: unknown[];
+  queryKey: QueryKey;
   fetcher: () => Promise<unknown>;
   ttlMs: number;
 }> = [

--- a/src/features/boss/BossEncounterPanel.tsx
+++ b/src/features/boss/BossEncounterPanel.tsx
@@ -50,7 +50,7 @@ export function BossEncounterPanel(): JSX.Element {
                       type="button"
                       onClick={() => {
                         updateConfig('boss', entry);
-                        updateConfig('bossModeId', entry.modes.at(0)?.id ?? null);
+                        updateConfig('bossModeId', entry.modes[0]?.id ?? null);
                       }}
                       className={clsx(
                         'flex w-full flex-col gap-1 px-4 py-3 text-left hover:bg-slate-900/60',
@@ -74,7 +74,7 @@ export function BossEncounterPanel(): JSX.Element {
             {boss ? (
               <div className="mt-3 space-y-3">
                 <select
-                  value={bossModeId ?? boss.modes.at(0)?.id ?? ''}
+                  value={bossModeId ?? boss.modes[0]?.id ?? ''}
                   onChange={(event) => updateConfig('bossModeId', event.target.value)}
                   className="w-full rounded border border-slate-800 bg-slate-900/80 px-3 py-2 text-sm focus:border-emerald-500 focus:outline-none"
                 >

--- a/src/hooks/useApiHealth.ts
+++ b/src/hooks/useApiHealth.ts
@@ -12,7 +12,7 @@ export function useApiHealth() {
     await Promise.all(
       apiRegistry.map(async (entry) => {
         try {
-          await queryClient.fetchQuery(entry.queryKey, entry.fetcher);
+          await queryClient.fetchQuery({ queryKey: entry.queryKey, queryFn: entry.fetcher });
           setFreshness(entry.key, { updatedAt: Date.now(), ttl: entry.ttlMs });
         } catch (error) {
           registerError(entry.key, error instanceof Error ? error.message : 'Unknown error');

--- a/src/layout/TopNav.tsx
+++ b/src/layout/TopNav.tsx
@@ -10,7 +10,8 @@ export function TopNav(): JSX.Element {
     const sorted = Object.entries(freshness)
       .filter(([, meta]) => meta)
       .sort(([, a], [, b]) => (b?.updatedAt ?? 0) - (a?.updatedAt ?? 0));
-    return sorted.at(0)?.[1] ?? null;
+    const newestEntry = sorted[0];
+    return newestEntry ? newestEntry[1] ?? null : null;
   }, [freshness]);
 
   return (

--- a/src/state/ApiProvider.tsx
+++ b/src/state/ApiProvider.tsx
@@ -12,7 +12,10 @@ export function ApiProvider({ children }: PropsWithChildren): JSX.Element {
     await Promise.all(
       apiRegistry.map(async (entry) => {
         try {
-          const data = await queryClient.fetchQuery(entry.queryKey, entry.fetcher);
+          const data = await queryClient.fetchQuery({
+            queryKey: entry.queryKey,
+            queryFn: entry.fetcher
+          });
           setFreshness(entry.key, { updatedAt: Date.now(), ttl: entry.ttlMs });
           return data;
         } catch (error) {


### PR DESCRIPTION
## Summary
- update the API registry typing and consumers to use the TanStack Query v5 fetchQuery options object
- replace Array.prototype.at usages with index accessors for wider TypeScript target compatibility

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e42e7de0388330a5589b42f52cea9d